### PR TITLE
Updated Slow Tests and Tuning Scripts, Cleaned Some pytorch_dataset Documentation, Improved EIC Quantile Binning

### DIFF
--- a/src/meds_torch/configs/callbacks/ray.yaml
+++ b/src/meds_torch/configs/callbacks/ray.yaml
@@ -1,6 +1,5 @@
 defaults:
   - _self_
-  - default
 
 ray_callback:
   _target_: ray.train.lightning.RayTrainReportCallback

--- a/src/meds_torch/configs/callbacks/tune_default.yaml
+++ b/src/meds_torch/configs/callbacks/tune_default.yaml
@@ -1,22 +1,9 @@
 defaults:
   - ray
-  - model_checkpoint
   - early_stopping
-  - model_summary
   - _self_
-
-model_checkpoint:
-  dirpath: ${paths.time_output_dir}/checkpoints
-  filename: "epoch_{epoch:03d}"
-  monitor: "val/loss"
-  mode: "min"
-  save_last: True
-  auto_insert_metric_name: False
 
 early_stopping:
   monitor: "val/loss"
   patience: 3
   mode: "min"
-
-model_summary:
-  max_depth: -1

--- a/src/meds_torch/configs/data/pytorch_dataset.yaml
+++ b/src/meds_torch/configs/data/pytorch_dataset.yaml
@@ -7,6 +7,10 @@ cache_dir: ${paths.data_dir}/.pytorch_dataset_cache_dir/
 code_metadata_fp: ${paths.data_dir}/metadata/codes.parquet
 schema_files_root: ${paths.data_dir}/tokenization/schemas
 tasks_root: ${paths.meds_cohort_dir}/tasks
+split_names:
+    train: train # training data is in ${paths.data_dir}/${split_names.train}**/*.nrt
+    validate: tuning # tuning data is in ${paths.data_dir}/${split_names.validate}/**/*.nrt
+    test: held_out # held_out data is in ${paths.data_dir}/${split_names.test}/**/*.nrt
 
 # Task params
 task_root_dir: null

--- a/src/meds_torch/configs/finetune.yaml
+++ b/src/meds_torch/configs/finetune.yaml
@@ -31,6 +31,8 @@ name: "finetune"
 # task name, determines output directory path
 task_name: null
 
+test_devices: "1"
+
 # tags to help you identify your experiments
 # you can overwrite this in experiment configs
 # overwrite from command line with `python train.py tags="[first_tag, second_tag]"`

--- a/src/meds_torch/configs/finetune.yaml
+++ b/src/meds_torch/configs/finetune.yaml
@@ -57,4 +57,4 @@ ckpt_path: null
 seed: null
 
 # When tuning, setting this to 0 will desable ray memory monitor, which often crashes
-ray_memory_monitor_refresh_ms: 0
+ray_memory_monitor_refresh_ms: "0"

--- a/src/meds_torch/configs/finetune.yaml
+++ b/src/meds_torch/configs/finetune.yaml
@@ -55,3 +55,6 @@ ckpt_path: null
 
 # seed for random number generators in pytorch, numpy and python.random
 seed: null
+
+# When tuning, setting this to 0 will desable ray memory monitor, which often crashes
+ray_memory_monitor_refresh_ms: 0

--- a/src/meds_torch/configs/train.yaml
+++ b/src/meds_torch/configs/train.yaml
@@ -55,4 +55,4 @@ ckpt_path: null
 seed: null
 
 # When tuning, setting this to 0 will desable ray memory monitor, which often crashes
-ray_memory_monitor_refresh_ms: 0
+ray_memory_monitor_refresh_ms: "0"

--- a/src/meds_torch/configs/train.yaml
+++ b/src/meds_torch/configs/train.yaml
@@ -29,6 +29,8 @@ defaults:
 
 name: "train"
 
+test_devices: "1"
+
 best_config_path: null
 
 # task name, determines output directory path

--- a/src/meds_torch/configs/train.yaml
+++ b/src/meds_torch/configs/train.yaml
@@ -53,3 +53,6 @@ ckpt_path: null
 
 # seed for random number generators in pytorch, numpy and python.random
 seed: null
+
+# When tuning, setting this to 0 will desable ray memory monitor, which often crashes
+ray_memory_monitor_refresh_ms: 0

--- a/src/meds_torch/configs/trainer/ray.yaml
+++ b/src/meds_torch/configs/trainer/ray.yaml
@@ -1,8 +1,23 @@
-defaults:
-  - default
+_target_: lightning.pytorch.trainer.Trainer
 
-accelerator: gpu
-devices: 1
+accelerator: "auto"
+devices: "auto"
 
-plugins:
-  - __target__: ray.train.lightning.LightningEnvironment
+default_root_dir: ${paths.time_output_dir}
+
+min_epochs: 1 # prevents early stopping
+max_epochs: 2
+
+# mixed precision for extra speed-up
+# precision: 16
+
+# perform a validation loop every N training epochs
+check_val_every_n_epoch: 1
+
+# set True to to ensure deterministic results
+# makes training slower but gives more reproducibility than just setting seeds
+deterministic: False
+
+strategy:
+  _target_: ray.train.lightning.RayDDPStrategy
+  find_unused_parameters: True

--- a/src/meds_torch/data/components/pytorch_dataset.py
+++ b/src/meds_torch/data/components/pytorch_dataset.py
@@ -217,11 +217,14 @@ class PytorchDataset(SeedableMixin, torch.utils.data.Dataset, TimeableMixin):
 
         Returns:
             dict: A dictionary containing the data for the specified index. The structure typically includes:
-                - 'time_delta_days': List of time deltas between events.
-                - 'dynamic_indices': List of categorical metadata elements.
-                - 'dynamic_values': List of numerical metadata elements.
-                - 'static_indices': List of static categorical metadata elements.
-                Additional keys may be present based on the dataset configuration.
+                - code: List of categorical metadata elements.
+                - mask: Mask of valid elements in the sequence, False means it is a padded element.
+                - numeric_value: List of dynamic numeric values.
+                - numeric_value_mask: Mask of numeric values (False means no numeric value was recorded)
+                - time_delta_days: List of dynamic time deltas between observations.
+                - static_indices(Optional): List of static MEDS codes.
+                - static_values(Optional): List of static MEDS numeric values.
+                - static_mask(Optional): List of static masks (True means the value is static).
 
         Notes:
             This method uses the SeedableMixin to ensure reproducibility in data loading.
@@ -388,8 +391,7 @@ class PytorchDataset(SeedableMixin, torch.utils.data.Dataset, TimeableMixin):
                 returned by the __getitem__ method.
 
         Returns:
-            dict: A dictionary containing the collated batch data. The exact structure depends on the
-                collation strategy used.
+            dict: A dictionary containing the collated batch data.
         """
 
         data = JointNestedRaggedTensorDict.vstack([item["dynamic"] for item in batch]).to_dense()
@@ -402,6 +404,6 @@ class PytorchDataset(SeedableMixin, torch.utils.data.Dataset, TimeableMixin):
 
         # Add task labels to batch
         for k in batch[0].keys():
-            if k not in ("dynamic", "static_values", "static_indices"):
+            if k not in ("dynamic", "static_values", "static_indices", "static_mask"):
                 tensorized[k] = torch.Tensor([item[k] for item in batch])
         return tensorized

--- a/src/meds_torch/data/components/pytorch_dataset.py
+++ b/src/meds_torch/data/components/pytorch_dataset.py
@@ -111,17 +111,19 @@ class PytorchDataset(SeedableMixin, torch.utils.data.Dataset, TimeableMixin):
         This method processes the Parquet files for each shard in the dataset, extracting static data and
         creating various mappings and indices for efficient data access.
 
-        The method populates the following instance attributes: - self.static_dfs: Dictionary of static
-        DataFrames for each shard. - self.subj_indices: Mapping of subject IDs to their indices. -
-        self.subj_seq_bounds: Dictionary of sequence bounds for each subject. - self.index: List of
-        (subject_id, start, end) tuples for data access. - self.labels: Dictionary of task labels (if tasks
-        are specified).
+        The method populates the following instance attributes:
+        - self.static_dfs: Dictionary of static DataFrames for each shard.
+        - self.subj_indices: Mapping of subject IDs to their indices.
+        - self.subj_seq_bounds: Dictionary of sequence bounds for each subject.
+        - self.index: List of (subject_id, start, end) tuples for data access.
+        - self.labels: Dictionary of task labels (if tasks are specified).
 
-        If tasks are specified in the configuration, this method also processes the task labels and integrates
-        them with the static data.
+        If a task is specified in the configuration, this method also processes the task labels and
+        integrates them with the static data.
 
-        Raises:     ValueError: If duplicate subjects are found across shards or if                 required
-        task information is missing.     FileNotFoundError: If specified task files are not found.
+        Raises:
+            ValueError: If duplicate subjects are found across shards.
+            FileNotFoundError: If specified task files are not found.
         """
 
         schema_root = Path(self.config.schema_files_root)
@@ -210,18 +212,19 @@ class PytorchDataset(SeedableMixin, torch.utils.data.Dataset, TimeableMixin):
         This method returns a dictionary corresponding to a single subject's data at the specified index. The
         data is not tensorized in this method, as that work is typically done in the collate function.
 
-        Args:     idx (int): The index of the data point to retrieve.
+        Args:
+            idx (int): The index of the data point to retrieve.
 
-        Returns:     dict: A dictionary containing the data for the specified index. The structure typically
-        includes:         - 'time_delta_days': List of time deltas between events.         -
-        'dynamic_indices': List of categorical metadata elements.         - 'dynamic_values': List of
-        numerical metadata elements.         - 'static_indices': List of static categorical metadata elements.
-        Additional keys may be present based on the dataset configuration.
+        Returns:
+            dict: A dictionary containing the data for the specified index. The structure typically includes:
+                - 'time_delta_days': List of time deltas between events.
+                - 'dynamic_indices': List of categorical metadata elements.
+                - 'dynamic_values': List of numerical metadata elements.
+                - 'static_indices': List of static categorical metadata elements.
+                Additional keys may be present based on the dataset configuration.
 
-        Notes:     - The exact structure of the output dictionary depends on the dataset configuration and the
-        collate type specified.     - This method uses the SeedableMixin to ensure reproducibility in data
-        loading.     - The returned data is typically in a 'raw' format and may require further processing or
-        tensorization in the collate function.
+        Notes:
+            This method uses the SeedableMixin to ensure reproducibility in data loading.
         """
         return self._seeded_getitem(idx)
 
@@ -249,21 +252,27 @@ class PytorchDataset(SeedableMixin, torch.utils.data.Dataset, TimeableMixin):
         This method retrieves and processes the data for a specific subject, applying various transformations
         and filters based on the dataset configuration.
 
-        Args:     subject_dynamic_data: The dynamic data for the subject.     subject_id (int): The ID of the
-        subject to load.     st (int): The start index of the sequence to load.     end (int): The end index
-        of the sequence to load.
+        Args:
+            subject_dynamic_data: The dynamic data for the subject.
+            subject_id (int): The ID of the subject to load.
+            st (int): The start index of the sequence to load.
+            end (int): The end index of the sequence to load.
 
-        Returns:     dict: A dictionary containing the processed data for the subject. The exact contents
-        depend on the dataset configuration but typically include:           - Static data (indices and
-        values)           - Dynamic data (time series data, event codes, etc.)           - Sequence
-        information (start and end indices, if configured)
+        Returns:
+            dict: A dictionary containing the processed data for the subject. The exact contents
+                depend on the dataset configuration but typically include:
+                - Static data (indices and values)
+                - Dynamic data (time series data, event codes, etc.)
+                - Sequence information (start and end indices, if configured)
 
-        Raises:     ValueError: If the sequence length is invalid or if there are inconsistencies in the data
-        shapes.
+        Raises:
+            ValueError: If the sequence length is invalid or if there are inconsistencies in the data shapes.
 
-        Notes:     - This method applies sequence length constraints and sampling strategies       as
-        specified in the dataset configuration.     - The method is decorated with @SeedableMixin.WithSeed to
-        ensure reproducibility.
+        Notes:
+            - This method applies sequence length constraints and sampling strategies as
+                specified in the dataset configuration.
+            - It handles different collate types (event_stream, triplet, etc.) differently.
+            - The method is decorated with @SeedableMixin.WithSeed to ensure reproducibility.
         """
         shard = self.subj_map[subject_id]
         subject_idx = self.subj_indices[subject_id]
@@ -369,23 +378,18 @@ class PytorchDataset(SeedableMixin, torch.utils.data.Dataset, TimeableMixin):
 
     @TimeableMixin.TimeAs
     def collate(self, batch: list[dict]) -> dict:
-        """Combine a batch of data points into a single, tensorized batch.
+        """Combines a batch of data points into a single, tensorized batch.
 
-        This method serves as the main collation function, handling different collation strategies based on
-        the dataset configuration. It delegates to specific collation methods depending on the collate_type
-        specified in the configuration.
+        The collated output is a fully tensorized and padded dictionary, ready for input into an
+        `input_encoder`. This method uses the JointNestedRaggedTensorDict API to collate and pad the data.
 
-        Args:     batch (list[dict]): A list of dictionaries, each representing a single data point as
-        returned by the __getitem__ method.
+        Args:
+            batch (list[dict]): A list of dictionaries, each representing a single sample as
+                returned by the __getitem__ method.
 
-        Returns:     dict: A dictionary containing the collated batch data. The exact structure depends on the
-        collation strategy used.
-
-        Raises:     NotImplementedError: If an unsupported collate type is specified in the configuration.
-
-        Notes:     - The method supports various collation strategies including triplet, triplet_prompt, eic.
-        - Each collation strategy is optimized for different model architectures and data representations.
-          - The collated output is fully tensorized and padded, ready for input into a PyTorch model.
+        Returns:
+            dict: A dictionary containing the collated batch data. The exact structure depends on the
+                collation strategy used.
         """
 
         data = JointNestedRaggedTensorDict.vstack([item["dynamic"] for item in batch]).to_dense()

--- a/src/meds_torch/data/datamodule.py
+++ b/src/meds_torch/data/datamodule.py
@@ -155,14 +155,6 @@ class MEDSDataModule(LightningDataModule, Module):
             **self.cfg.dataloader,
         )
 
-    def teardown(self, stage: str | None = None) -> None:
-        """Lightning hook for cleaning up after `trainer.fit()`, `trainer.validate()`,
-        `trainer.test()`, and `trainer.predict()`.
-
-        :param stage: The stage being torn down. Either `"fit"`, `"validate"`, `"test"`, or `"predict"`.
-            Defaults to ``None``.
-        """
-
     def state_dict(self) -> dict[Any, Any]:
         """Called when saving a checkpoint. Implement to generate and save the
         datamodule state.

--- a/src/meds_torch/data/datamodule.py
+++ b/src/meds_torch/data/datamodule.py
@@ -110,13 +110,13 @@ class MEDSDataModule(LightningDataModule, Module):
 
         # load and split datasets only if not loaded already
         if stage == "test":
-            self.data_test = get_dataset(self.cfg, split="held_out")
+            self.data_test = get_dataset(self.cfg, split=self.split_names.test)
         elif stage == "validate":
-            self.data_val = get_dataset(self.cfg, split="tuning")
+            self.data_val = get_dataset(self.cfg, split=self.split_names.validate)
         else:
-            self.data_train = get_dataset(self.cfg, split="train")
-            self.data_val = get_dataset(self.cfg, split="tuning")
-            self.data_test = get_dataset(self.cfg, split="held_out")
+            self.data_train = get_dataset(self.cfg, split=self.split_names.train)
+            self.data_val = get_dataset(self.cfg, split=self.split_names.validate)
+            self.data_test = get_dataset(self.cfg, split=self.split_names.test)
 
     def train_dataloader(self) -> DataLoader[Any]:
         """Create and return the train dataloader.

--- a/src/meds_torch/data/datamodule.py
+++ b/src/meds_torch/data/datamodule.py
@@ -110,13 +110,13 @@ class MEDSDataModule(LightningDataModule, Module):
 
         # load and split datasets only if not loaded already
         if stage == "test":
-            self.data_test = get_dataset(self.cfg, split=self.split_names.test)
+            self.data_test = get_dataset(self.cfg, split=self.cfg.split_names.test)
         elif stage == "validate":
-            self.data_val = get_dataset(self.cfg, split=self.split_names.validate)
+            self.data_val = get_dataset(self.cfg, split=self.cfg.split_names.validate)
         else:
-            self.data_train = get_dataset(self.cfg, split=self.split_names.train)
-            self.data_val = get_dataset(self.cfg, split=self.split_names.validate)
-            self.data_test = get_dataset(self.cfg, split=self.split_names.test)
+            self.data_train = get_dataset(self.cfg, split=self.cfg.split_names.train)
+            self.data_val = get_dataset(self.cfg, split=self.cfg.split_names.validate)
+            self.data_test = get_dataset(self.cfg, split=self.cfg.split_names.test)
 
     def train_dataloader(self) -> DataLoader[Any]:
         """Create and return the train dataloader.

--- a/src/meds_torch/data/datamodule.py
+++ b/src/meds_torch/data/datamodule.py
@@ -79,15 +79,17 @@ class MEDSDataModule(LightningDataModule, Module):
         return 10
 
     def prepare_data(self) -> None:
-        """Download data if needed. Lightning ensures that `self.prepare_data()` is called only within a
-        single process on CPU, so you can safely add your downloading logic within. In case of multi-node
-        training, the execution of this hook depends upon `self.prepare_data_per_node()`.
+        """Download data if needed. Lightning ensures that `self.prepare_data()` is
+        called only within a single process on CPU, so you can safely add your
+        downloading logic within. In case of multi-node training, the execution of this
+        hook depends upon `self.prepare_data_per_node()`.
 
         Do not use it to assign state (self.x = y).
         """
 
     def setup(self, stage: str | None = None) -> None:
-        """Load data. Set variables: `self.data_train`, `self.data_val`, `self.data_test`.
+        """Load data. Set variables: `self.data_train`, `self.data_val`,
+        `self.data_test`.
 
         This method is called by Lightning before `trainer.fit()`, `trainer.validate()`, `trainer.test()`, and
         `trainer.predict()`, so be careful not to execute things like random split twice! Also, it is called
@@ -107,10 +109,13 @@ class MEDSDataModule(LightningDataModule, Module):
             self.batch_size_per_device = self.hparams.cfg.dataloader.batch_size // self.trainer.world_size
 
         # load and split datasets only if not loaded already
-        self.data_train = get_dataset(self.cfg, split="train")
-        if stage != "train":  # TODO: remove this after we have more test data
+        if stage == "test":
+            self.data_test = get_dataset(self.cfg, split="held_out")
+        elif stage == "validate":
             self.data_val = get_dataset(self.cfg, split="tuning")
-        if stage in ["test", None]:
+        else:
+            self.data_train = get_dataset(self.cfg, split="train")
+            self.data_val = get_dataset(self.cfg, split="tuning")
             self.data_test = get_dataset(self.cfg, split="held_out")
 
     def train_dataloader(self) -> DataLoader[Any]:
@@ -151,23 +156,24 @@ class MEDSDataModule(LightningDataModule, Module):
         )
 
     def teardown(self, stage: str | None = None) -> None:
-        """Lightning hook for cleaning up after `trainer.fit()`, `trainer.validate()`, `trainer.test()`, and
-        `trainer.predict()`.
+        """Lightning hook for cleaning up after `trainer.fit()`, `trainer.validate()`,
+        `trainer.test()`, and `trainer.predict()`.
 
         :param stage: The stage being torn down. Either `"fit"`, `"validate"`, `"test"`, or `"predict"`.
             Defaults to ``None``.
         """
 
     def state_dict(self) -> dict[Any, Any]:
-        """Called when saving a checkpoint. Implement to generate and save the datamodule state.
+        """Called when saving a checkpoint. Implement to generate and save the
+        datamodule state.
 
         :return: A dictionary containing the datamodule state that you want to save.
         """
         return {}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        """Called when loading a checkpoint. Implement to reload datamodule state given datamodule
-        `state_dict()`.
+        """Called when loading a checkpoint. Implement to reload datamodule state given
+        datamodule `state_dict()`.
 
         :param state_dict: The datamodule state returned by `self.state_dict()`.
         """

--- a/src/meds_torch/eval.py
+++ b/src/meds_torch/eval.py
@@ -1,5 +1,4 @@
 from importlib.resources import files
-from pathlib import Path
 from typing import Any
 
 import hydra
@@ -34,8 +33,6 @@ def evaluate(cfg: DictConfig, datamodule=None) -> tuple[dict[str, Any], dict[str
     Returns:
         Tuple[dict, dict] with metrics and dict with all instantiated objects.
     """
-    cfg.paths.time_output_dir = Path(cfg.paths.time_output_dir)
-    cfg.paths.time_output_dir.makedirs(exist_ok=True)
     assert cfg.ckpt_path
 
     log.info(f"Instantiating datamodule <{cfg.data._target_}>")

--- a/src/meds_torch/eval.py
+++ b/src/meds_torch/eval.py
@@ -1,5 +1,5 @@
-import os
 from importlib.resources import files
+from pathlib import Path
 from typing import Any
 
 import hydra
@@ -34,6 +34,8 @@ def evaluate(cfg: DictConfig, datamodule=None) -> tuple[dict[str, Any], dict[str
     Returns:
         Tuple[dict, dict] with metrics and dict with all instantiated objects.
     """
+    cfg.paths.time_output_dir = Path(cfg.paths.time_output_dir)
+    cfg.paths.time_output_dir.makedirs(exist_ok=True)
     assert cfg.ckpt_path
 
     log.info(f"Instantiating datamodule <{cfg.data._target_}>")
@@ -81,7 +83,6 @@ def main(cfg: DictConfig) -> None:
     """
     # apply extra utilities
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
-    os.makedirs(cfg.paths.time_output_dir, exist_ok=True)
     extras(cfg)
 
     evaluate(cfg)

--- a/src/meds_torch/eval.py
+++ b/src/meds_torch/eval.py
@@ -3,6 +3,7 @@ from importlib.resources import files
 from typing import Any
 
 import hydra
+import torch
 from lightning import LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
@@ -25,11 +26,13 @@ config_yaml = files("meds_torch").joinpath("configs/eval.yaml")
 def evaluate(cfg: DictConfig, datamodule=None) -> tuple[dict[str, Any], dict[str, Any]]:
     """Evaluates given checkpoint on a datamodule testset.
 
-    This method is wrapped in optional @task_wrapper decorator, that controls the behavior during failure.
-    Useful for multiruns, saving info about the crash, etc.
+    This method is wrapped in optional @task_wrapper decorator, that controls the
+    behavior during failure. Useful for multiruns, saving info about the crash, etc.
 
-    :param cfg: DictConfig configuration composed by Hydra.
-    :return: Tuple[dict, dict] with metrics and dict with all instantiated objects.
+    Args:
+        cfg: DictConfig configuration composed by Hydra.
+    Returns:
+        Tuple[dict, dict] with metrics and dict with all instantiated objects.
     """
     assert cfg.ckpt_path
 
@@ -39,6 +42,7 @@ def evaluate(cfg: DictConfig, datamodule=None) -> tuple[dict[str, Any], dict[str
 
     log.info(f"Instantiating model <{cfg.model._target_}>")
     model: LightningModule = hydra.utils.instantiate(cfg.model)
+    model.load_state_dict(torch.load(cfg.ckpt_path)["state_dict"])
 
     log.info("Instantiating loggers...")
     logger: list[Logger] = instantiate_loggers(cfg.get("logger"))
@@ -59,7 +63,7 @@ def evaluate(cfg: DictConfig, datamodule=None) -> tuple[dict[str, Any], dict[str
         log_hyperparameters(object_dict)
 
     log.info("Starting testing!")
-    trainer.test(model=model, datamodule=datamodule, ckpt_path=cfg.ckpt_path)
+    trainer.test(model=model, datamodule=datamodule)
 
     # for predictions use trainer.predict(...)
     # predictions = trainer.predict(model=model, dataloaders=dataloaders, ckpt_path=cfg.ckpt_path)

--- a/src/meds_torch/finetune.py
+++ b/src/meds_torch/finetune.py
@@ -1,4 +1,3 @@
-import os
 from importlib.resources import files
 from pathlib import Path
 from typing import Any
@@ -109,7 +108,8 @@ def finetune(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
         A tuple with metrics and dict with all instantiated objects.
     """
     # cache hydra config
-    os.makedirs(cfg.paths.time_output_dir, exist_ok=True)
+    cfg.paths.time_output_dir = Path(cfg.paths.time_output_dir)
+    cfg.paths.time_output_dir.makedirs(exist_ok=True)
     OmegaConf.save(config=cfg, f=Path(cfg.paths.time_output_dir) / "hydra_config.yaml")
 
     object_dict = initialize_finetune_objects(cfg)
@@ -157,7 +157,6 @@ def main(cfg: DictConfig) -> float | None:
     """
     # apply extra utilities
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
-    os.makedirs(cfg.paths.time_output_dir, exist_ok=True)
     extras(cfg)
 
     # train the model

--- a/src/meds_torch/finetune.py
+++ b/src/meds_torch/finetune.py
@@ -26,33 +26,26 @@ log = RankedLogger(__name__, rank_zero_only=True)
 config_yaml = files("meds_torch").joinpath("configs/finetune.yaml")
 
 
-@task_wrapper
-def finetune(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Trains the model. Can additionally evaluate on a testset, using best weights obtained during training.
-
-    This method is wrapped in optional @task_wrapper decorator, that controls the behavior during failure.
-    Useful for multiruns, saving info about the crash, etc.
+def initialize_finetune_objects(cfg: DictConfig, **kwargs) -> Trainer:
+    """Instantiates a Lightning Trainer object.
 
     :param cfg: A DictConfig configuration composed by Hydra.
-    :return: A tuple with metrics and dict with all instantiated objects.
+    :return: A Lightning Trainer object.
     """
     # load pretrained backbone and input encoder:
+    # set seed for random number generators in pytorch, numpy and python.random
     pretrain_cfg = OmegaConf.load(cfg.pretrain_yaml_path)
     # TODO this just adds backwards compatibility find a better way for loading pretrain_cfg
     # see: https://github.com/Oufattole/meds-torch/issues/47
     with open_dict(pretrain_cfg):
-        pretrain_cfg.model.max_seq_len = cfg.data.max_seq_len
-        pretrain_cfg.model.input_encoder.max_seq_len = cfg.data.max_seq_len
+        pretrain_cfg.model._resolved_max_seq_len = cfg.data._resolved_max_seq_len
+        pretrain_cfg.model.input_encoder._resolved_max_seq_len = cfg.data._resolved_max_seq_len
         pretrain_cfg.data.vocab_size = cfg.data.vocab_size
         pretrain_cfg.model.vocab_size = cfg.data.vocab_size
 
     pretrain_model: LightningModule = hydra.utils.instantiate(pretrain_cfg.model)
     ckpt = torch.load(cfg.pretrain_ckpt_path)
     pretrain_model.load_state_dict(ckpt["state_dict"])
-
-    # cache hydra config
-    os.makedirs(cfg.paths.time_output_dir, exist_ok=True)
-    OmegaConf.save(config=cfg, f=Path(cfg.paths.time_output_dir) / "hydra_config.yaml")
 
     # set seed for random number generators in pytorch, numpy and python.random
     if cfg.get("seed"):
@@ -87,7 +80,10 @@ def finetune(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     logger: list[Logger] = instantiate_loggers(cfg.get("logger"))
 
     log.info(f"Instantiating trainer <{cfg.trainer._target_}>")
-    trainer: Trainer = hydra.utils.instantiate(cfg.trainer, callbacks=callbacks, logger=logger)
+    trainer_factory: Trainer = hydra.utils.instantiate(
+        cfg.trainer, callbacks=callbacks, logger=logger, _partial_=True
+    )
+    trainer = trainer_factory(**kwargs)
 
     object_dict = {
         "cfg": cfg,
@@ -97,6 +93,33 @@ def finetune(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
         "logger": logger,
         "trainer": trainer,
     }
+
+    return object_dict
+
+
+@task_wrapper
+def finetune(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Trains the model. Can additionally evaluate on a testset, using best weights
+    obtained during training.
+
+    This method is wrapped in optional @task_wrapper decorator, that controls the
+    behavior during failure. Useful for multiruns, saving info about the crash, etc.
+
+    Args:
+        cfg: A DictConfig configuration composed by Hydra.
+    Returns:
+        A tuple with metrics and dict with all instantiated objects.
+    """
+    # cache hydra config
+    os.makedirs(cfg.paths.time_output_dir, exist_ok=True)
+    OmegaConf.save(config=cfg, f=Path(cfg.paths.time_output_dir) / "hydra_config.yaml")
+
+    object_dict = initialize_finetune_objects(cfg)
+
+    logger = object_dict["logger"]
+    trainer = object_dict["trainer"]
+    model = object_dict["model"]
+    datamodule = object_dict["datamodule"]
 
     if logger:
         log.info("Logging hyperparameters!")
@@ -129,8 +152,10 @@ def finetune(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
 def main(cfg: DictConfig) -> float | None:
     """Main entry point for training.
 
-    :param cfg: DictConfig configuration composed by Hydra.
-    :return: Optional[float] with optimized metric value.
+    Args:
+        cfg: DictConfig configuration composed by Hydra.
+    Returns:
+        Optional[float] with optimized metric value.
     """
     # apply extra utilities
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)

--- a/src/meds_torch/finetune.py
+++ b/src/meds_torch/finetune.py
@@ -38,8 +38,6 @@ def initialize_finetune_objects(cfg: DictConfig, **kwargs) -> Trainer:
     # TODO this just adds backwards compatibility find a better way for loading pretrain_cfg
     # see: https://github.com/Oufattole/meds-torch/issues/47
     with open_dict(pretrain_cfg):
-        pretrain_cfg.model._resolved_max_seq_len = cfg.data._resolved_max_seq_len
-        pretrain_cfg.model.input_encoder._resolved_max_seq_len = cfg.data._resolved_max_seq_len
         pretrain_cfg.data.vocab_size = cfg.data.vocab_size
         pretrain_cfg.model.vocab_size = cfg.data.vocab_size
 

--- a/src/meds_torch/finetune.py
+++ b/src/meds_torch/finetune.py
@@ -1,5 +1,4 @@
 from importlib.resources import files
-from pathlib import Path
 from typing import Any
 
 import hydra
@@ -107,11 +106,6 @@ def finetune(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     Returns:
         A tuple with metrics and dict with all instantiated objects.
     """
-    # cache hydra config
-    cfg.paths.time_output_dir = Path(cfg.paths.time_output_dir)
-    cfg.paths.time_output_dir.makedirs(exist_ok=True)
-    OmegaConf.save(config=cfg, f=Path(cfg.paths.time_output_dir) / "hydra_config.yaml")
-
     object_dict = initialize_finetune_objects(cfg)
 
     logger = object_dict["logger"]

--- a/src/meds_torch/train.py
+++ b/src/meds_torch/train.py
@@ -1,7 +1,5 @@
-import os
 import shutil
 from importlib.resources import files
-from pathlib import Path
 from typing import Any
 
 import hydra
@@ -9,7 +7,7 @@ import lightning as L
 import loguru
 from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
 
 from meds_torch.utils import (
     RankedLogger,
@@ -81,8 +79,6 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
         A tuple with metrics and dict with all instantiated objects.
     """
     # cache hydra config
-    os.makedirs(cfg.paths.time_output_dir, exist_ok=True)
-    OmegaConf.save(config=cfg, f=Path(cfg.paths.time_output_dir) / "hydra_config.yaml")
 
     object_dict = initialize_train_objects(cfg)
     logger = object_dict["logger"]
@@ -132,7 +128,6 @@ def main(cfg: DictConfig) -> float | None:
     """
     # apply extra utilities
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
-    os.makedirs(cfg.paths.time_output_dir, exist_ok=True)
     extras(cfg)
 
     # train the model
@@ -141,7 +136,7 @@ def main(cfg: DictConfig) -> float | None:
     # safely retrieve metric value for hydra-based hyperparameter optimization
     metric_value = get_metric_value(metric_dict=metric_dict, metric_name=cfg.get("optimized_metric"))
 
-    checkpoint_dir = Path(cfg.paths.time_output_dir) / "checkpoints"
+    checkpoint_dir = cfg.paths.time_output_dir / "checkpoints"
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
     if not cfg.trainer.get("fast_dev_run"):

--- a/src/meds_torch/train.py
+++ b/src/meds_torch/train.py
@@ -27,20 +27,12 @@ log = RankedLogger(__name__, rank_zero_only=True)
 config_yaml = files("meds_torch").joinpath("configs/train.yaml")
 
 
-@task_wrapper
-def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Trains the model. Can additionally evaluate on a testset, using best weights obtained during training.
-
-    This method is wrapped in optional @task_wrapper decorator, that controls the behavior during failure.
-    Useful for multiruns, saving info about the crash, etc.
+def initialize_train_objects(cfg: DictConfig, **kwargs) -> Trainer:
+    """Instantiates a Lightning Trainer object.
 
     :param cfg: A DictConfig configuration composed by Hydra.
-    :return: A tuple with metrics and dict with all instantiated objects.
+    :return: A Lightning Trainer object.
     """
-    # cache hydra config
-    os.makedirs(cfg.paths.time_output_dir, exist_ok=True)
-    OmegaConf.save(config=cfg, f=Path(cfg.paths.time_output_dir) / "hydra_config.yaml")
-
     # set seed for random number generators in pytorch, numpy and python.random
     if cfg.get("seed"):
         L.seed_everything(cfg.seed, workers=True)
@@ -58,7 +50,10 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     logger: list[Logger] = instantiate_loggers(cfg.get("logger"))
 
     log.info(f"Instantiating trainer <{cfg.trainer._target_}>")
-    trainer: Trainer = hydra.utils.instantiate(cfg.trainer, callbacks=callbacks, logger=logger)
+    trainer_factory: Trainer = hydra.utils.instantiate(
+        cfg.trainer, callbacks=callbacks, logger=logger, _partial_=True
+    )
+    trainer = trainer_factory(**kwargs)
 
     object_dict = {
         "cfg": cfg,
@@ -68,6 +63,32 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
         "logger": logger,
         "trainer": trainer,
     }
+
+    return object_dict
+
+
+@task_wrapper
+def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Trains the model. Can additionally evaluate on a testset, using best weights
+    obtained during training.
+
+    This method is wrapped in optional @task_wrapper decorator, that controls the
+    behavior during failure. Useful for multiruns, saving info about the crash, etc.
+
+    Args:
+        cfg: A DictConfig configuration composed by Hydra.
+    Returns:
+        A tuple with metrics and dict with all instantiated objects.
+    """
+    # cache hydra config
+    os.makedirs(cfg.paths.time_output_dir, exist_ok=True)
+    OmegaConf.save(config=cfg, f=Path(cfg.paths.time_output_dir) / "hydra_config.yaml")
+
+    object_dict = initialize_train_objects(cfg)
+    logger = object_dict["logger"]
+    trainer = object_dict["trainer"]
+    model = object_dict["model"]
+    datamodule = object_dict["datamodule"]
 
     if logger:
         log.info("Logging hyperparameters!")
@@ -104,8 +125,10 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
 def main(cfg: DictConfig) -> float | None:
     """Main entry point for training.
 
-    :param cfg: DictConfig configuration composed by Hydra.
-    :return: Optional[float] with optimized metric value.
+    Args:
+        cfg: DictConfig configuration composed by Hydra.
+    Returns:
+        Optional[float] with optimized metric value.
     """
     # apply extra utilities
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)

--- a/src/meds_torch/tune.py
+++ b/src/meds_torch/tune.py
@@ -20,7 +20,7 @@ from ray.train.torch import TorchTrainer
 from meds_torch.eval import evaluate
 from meds_torch.finetune import initialize_finetune_objects
 from meds_torch.train import initialize_train_objects
-from meds_torch.utils import RankedLogger, extras
+from meds_torch.utils import RankedLogger, extras, task_wrapper
 from meds_torch.utils.resolvers import setup_resolvers
 
 log = RankedLogger(__name__, rank_zero_only=True)
@@ -29,6 +29,7 @@ setup_resolvers()
 config_yaml = files("meds_torch").joinpath("configs/train.yaml")
 
 
+@task_wrapper
 def ray_tune_runner(cfg: DictConfig, train_func: Callable):
     def objective(config):
         setup_resolvers()

--- a/src/meds_torch/tune.py
+++ b/src/meds_torch/tune.py
@@ -129,7 +129,7 @@ def main(cfg: DictConfig) -> float | None:
     Returns:
         Optional[float] with optimized metric value.
     """
-    os.environ["RAY_memory_monitor_refresh_ms"] = "0"
+    os.environ["RAY_memory_monitor_refresh_ms"] = cfg.ray_memory_monitor_refresh_ms
     # apply extra utilities
     os.makedirs(cfg.paths.time_output_dir, exist_ok=True)
     OmegaConf.save(config=cfg, f=Path(cfg.paths.time_output_dir) / "hydra_config.yaml")

--- a/src/meds_torch/tune.py
+++ b/src/meds_torch/tune.py
@@ -140,7 +140,7 @@ def main(cfg: DictConfig) -> float | None:
             raise FileNotFoundError(f"Best config file not found at {cfg.best_config_path}")
         logger.info(f"Loading best tuning config from {cfg.best_config_path}")
         with open(Path(cfg.best_config_path)) as config_json:
-            best_config = json.load(config_json)
+            best_config = json.load(config_json)["train_loop_config"]
         for key, value in best_config.items():
             OmegaConf.update(cfg, key, value, merge=False)
     else:

--- a/src/meds_torch/utils/custom_normalization.py
+++ b/src/meds_torch/utils/custom_normalization.py
@@ -622,7 +622,7 @@ def quantile_normalize(
         >>> custom_quantiles = {"lab//A": {"values/quantile/0.5": 2}}
         >>> quantile_normalize(MEDS_df.lazy(), code_metadata, custom_quantiles=custom_quantiles
         ...     ).collect().sort("subject_id", "time", "code")
-            shape: (6, 4)
+        shape: (6, 4)
         ┌────────────┬─────────────────────┬──────┬───────────────┐
         │ subject_id ┆ time                ┆ code ┆ numeric_value │
         │ ---        ┆ ---                 ┆ ---  ┆ ---           │

--- a/src/meds_torch/utils/custom_normalization.py
+++ b/src/meds_torch/utils/custom_normalization.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""Transformations for normalizing MEDS datasets, across both categorical and continuous dimensions."""
+"""Transformations for normalizing MEDS datasets, across both categorical and continuous
+dimensions."""
 from pathlib import Path
 
 import hydra
@@ -10,10 +11,174 @@ from MEDS_transforms.mapreduce.mapper import map_over
 from omegaconf import DictConfig, OmegaConf
 
 
+def process_quantiles(df: pl.DataFrame) -> pl.DataFrame:
+    """Process quantiles in a DataFrame, using custom quantiles if available.
+
+    Args:
+        df: A Polars DataFrame containing columns for values/quantiles and optionally custom_quantiles
+
+    Returns:
+        A DataFrame with processed quantiles and updated code column
+
+    Examples:
+    >>> import polars as pl
+    >>> df = pl.DataFrame({
+    ...     "code": ["lab//A", "lab//B", "lab//C", "lab//D"],
+    ...     "numeric_value": [-1.0, 2.0, None, 0.0],
+    ...     "values/quantiles": [
+    ...         {"values/quantile/0.2": 0, "values/quantile/0.4": 1,
+    ...          "values/quantile/0.6": 2, "values/quantile/0.8": 3},
+    ...         {"values/quantile/0.2": 0, "values/quantile/0.4": 1,
+    ...          "values/quantile/0.6": 2, "values/quantile/0.8": 3},
+    ...         {"values/quantile/0.2": 0, "values/quantile/0.4": 1,
+    ...          "values/quantile/0.6": 2, "values/quantile/0.8": 3},
+    ...         {"values/quantile/0.2": 0, "values/quantile/0.4": 1,
+    ...          "values/quantile/0.6": 2, "values/quantile/0.8": 3}
+    ...     ],
+    ...     "custom_quantiles": [None,
+    ...         {"values/quantile/0.5": 1.5},
+    ...         None,
+    ...         None
+    ...     ],
+    ...     "code/vocab_index": [0, 1, 2, 3],
+    ... })
+    >>> result = process_quantiles(df)
+    >>> result.select(["code", "numeric_value"])
+    shape: (4, 2)
+    ┌──────────────┬───────────────┐
+    │ code         ┆ numeric_value │
+    │ ---          ┆ ---           │
+    │ str          ┆ f64           │
+    ╞══════════════╪═══════════════╡
+    │ lab//A//_Q_1 ┆ -1.0          │
+    │ lab//B//_Q_2 ┆ 2.0           │
+    │ lab//C       ┆ null          │
+    │ lab//D//_Q_1 ┆ 0.0           │
+    └──────────────┴───────────────┘
+    >>> # Test with only custom quantiles
+    >>> df_custom = pl.DataFrame({
+    ...     "code": ["lab//A", "lab//A", "lab//A"],
+    ...     "numeric_value": [-0.5, 1.0, 4.0],
+    ...     "values/quantiles": [
+    ...         {"values/quantile/0.2": 0, "values/quantile/0.4": 1,
+    ...          "values/quantile/0.6": 2, "values/quantile/0.8": 3},
+    ...         {"values/quantile/0.2": 0, "values/quantile/0.4": 1,
+    ...          "values/quantile/0.6": 2, "values/quantile/0.8": 3},
+    ...         {"values/quantile/0.2": 0, "values/quantile/0.4": 1,
+    ...          "values/quantile/0.6": 2, "values/quantile/0.8": 3},
+    ...     ],
+    ...     "custom_quantiles": [
+    ...         None,
+    ...         None,
+    ...         None,
+    ...     ],
+    ...     "code/vocab_index": [0, 0, 0],
+    ... })
+    >>> result_custom = process_quantiles(df_custom)
+    >>> result_custom.select(["code", "numeric_value"])
+    shape: (3, 2)
+    ┌──────────────┬───────────────┐
+    │ code         ┆ numeric_value │
+    │ ---          ┆ ---           │
+    │ str          ┆ f64           │
+    ╞══════════════╪═══════════════╡
+    │ lab//A//_Q_1 ┆ -0.5          │
+    │ lab//A//_Q_2 ┆ 1.0           │
+    │ lab//A//_Q_5 ┆ 4.0           │
+    └──────────────┴───────────────┘
+    """
+    # Use custom_quantiles if available, otherwise use values/quantiles
+    df = df.with_columns(
+        effective_quantiles=pl.when(pl.col("custom_quantiles").is_not_null())
+        .then(pl.col("custom_quantiles"))
+        .otherwise(pl.col("values/quantiles"))
+    )
+
+    # Unnest the effective_quantiles and calculate the quantile
+    quantile_columns = pl.selectors.starts_with("values/quantile/")
+    df = df.unnest("effective_quantiles").with_columns(
+        quantile=pl.when(pl.col("numeric_value").is_not_null()).then(
+            pl.sum_horizontal(quantile_columns.lt(pl.col("numeric_value"))).add(1)
+        )
+    )
+
+    # Create the new code with quantile information
+    code_quantile_concat = pl.concat_str(pl.col("code"), pl.lit("//_Q_"), pl.col("quantile"))
+    df = df.with_columns(
+        code=pl.when(pl.col("quantile").is_not_null()).then(code_quantile_concat).otherwise(pl.col("code"))
+    )
+
+    # Clean up intermediate columns
+    df = df.drop("quantile", "code/vocab_index", "values/quantiles", "custom_quantiles", quantile_columns)
+
+    return df
+
+
+def add_custom_quantiles_column(code_metadata: pl.DataFrame, custom_quantiles: dict) -> pl.DataFrame:
+    """Add a custom_quantiles column to code_metadata DataFrame based on provided
+    dictionary.
+
+    Args:
+        code_metadata: A Polars DataFrame containing code information
+        custom_quantiles: A dictionary mapping codes to their custom quantile values
+
+    Returns:
+        A DataFrame with an added custom_quantiles column
+
+    Examples:
+    >>> import polars as pl
+    >>> code_metadata = pl.DataFrame({
+    ...     "code": ["lab//A", "lab//B", "lab//C"],
+    ...     "code/vocab_index": [0, 1, 2]
+    ... })
+    >>> custom_quantiles = {
+    ...     "lab//A": {"values/quantile/0.5": 1.5},
+    ...     "lab//B": {"values/quantile/0.5": 2.5}
+    ... }
+    >>> result = add_custom_quantiles_column(code_metadata, custom_quantiles)
+    >>> result
+    shape: (3, 3)
+    ┌────────┬──────────────────┬──────────────────┐
+    │ code   ┆ code/vocab_index ┆ custom_quantiles │
+    │ ---    ┆ ---              ┆ ---              │
+    │ str    ┆ i64              ┆ struct[1]        │
+    ╞════════╪══════════════════╪══════════════════╡
+    │ lab//A ┆ 0                ┆ {1.5}            │
+    │ lab//B ┆ 1                ┆ {2.5}            │
+    │ lab//C ┆ 2                ┆ null             │
+    └────────┴──────────────────┴──────────────────┘
+
+    >>> # Test with empty custom_quantiles
+    >>> result = add_custom_quantiles_column(code_metadata, {})
+    >>> result
+    shape: (3, 3)
+    ┌────────┬──────────────────┬──────────────────┐
+    │ code   ┆ code/vocab_index ┆ custom_quantiles │
+    │ ---    ┆ ---              ┆ ---              │
+    │ str    ┆ i64              ┆ null             │
+    ╞════════╪══════════════════╪══════════════════╡
+    │ lab//A ┆ 0                ┆ null             │
+    │ lab//B ┆ 1                ┆ null             │
+    │ lab//C ┆ 2                ┆ null             │
+    └────────┴──────────────────┴──────────────────┘
+    """
+    # Convert custom_quantiles dict to a Polars Series
+    if isinstance(custom_quantiles, DictConfig):
+        custom_quantiles = OmegaConf.to_container(custom_quantiles)
+    custom_quantiles_series = pl.Series(
+        name="custom_quantiles",
+        values=[custom_quantiles.get(code) if code is not None else None for code in code_metadata["code"]],
+    )
+
+    # Add the custom_quantiles column to code_metadata
+    return code_metadata.with_columns(custom_quantiles_series)
+
+
 def convert_to_discrete_quantiles(
     meds_data: pl.DataFrame, code_metadata: pl.DataFrame, custom_quantiles
 ) -> pl.DataFrame:
-    """Converts the numeric values in a MEDS dataset to discrete quantiles that are added to the code name.
+    """Converts the numeric values in a MEDS dataset to discrete quantiles that are
+    added to the code name.
 
     Returns:
         - A new DataFrame with the quantile values added to the code name.
@@ -124,7 +289,8 @@ def convert_to_discrete_quantiles(
 def convert_metadata_codes_to_discrete_quantiles(
     code_metadata: pl.DataFrame, custom_quantiles
 ) -> pl.DataFrame:
-    """Converts the numeric values in a MEDS dataset to discrete quantiles that are added to the code name.
+    """Converts the numeric values in a MEDS dataset to discrete quantiles that are
+    added to the code name.
 
     Returns:
         - A new DataFrame with the quantile values added to the code name.
@@ -147,8 +313,8 @@ def convert_metadata_codes_to_discrete_quantiles(
     ...                 "values/quantile/0.6": 1, "values/quantile/0.8": 3},
     ...             {"values/quantile/0.2": -3, "values/quantile/0.4": -1,
     ...                 "values/quantile/0.6": 1, "values/quantile/0.8": 3},
-    ...             {"values/quantile/0.2": -3, "values/quantile/0.4": -1,
-    ...                 "values/quantile/0.6": 1, "values/quantile/0.8": 3},
+    ...             {"values/quantile/0.2": None, "values/quantile/0.4": None,
+    ...                 "values/quantile/0.6": None, "values/quantile/0.8": None},
     ...         ],
     ...     },
     ...     schema = {
@@ -166,24 +332,24 @@ def convert_metadata_codes_to_discrete_quantiles(
     >>> quantile_code_metadata = convert_metadata_codes_to_discrete_quantiles(
     ...    code_metadata, custom_quantiles)
     >>> quantile_code_metadata.sort("code/vocab_index")
-    shape: (27, 3)
-    ┌──────────────┬──────────────────┬─────────────────────┐
-    │ code         ┆ code/vocab_index ┆ values/quantiles    │
-    │ ---          ┆ ---              ┆ ---                 │
-    │ str          ┆ u32              ┆ struct[4]           │
-    ╞══════════════╪══════════════════╪═════════════════════╡
-    │ lab//A       ┆ 0                ┆ {-3.0,-1.0,1.0,3.0} │
-    │ lab//A//_Q_1 ┆ 1                ┆ {-3.0,-1.0,1.0,3.0} │
-    │ lab//A//_Q_2 ┆ 2                ┆ {-3.0,-1.0,1.0,3.0} │
-    │ lab//A//_Q_3 ┆ 3                ┆ {-3.0,-1.0,1.0,3.0} │
-    │ lab//A//_Q_4 ┆ 4                ┆ {-3.0,-1.0,1.0,3.0} │
-    │ …            ┆ …                ┆ …                   │
-    │ dx//D        ┆ 22               ┆ {-3.0,-1.0,1.0,3.0} │
-    │ dx//D//_Q_1  ┆ 23               ┆ {-3.0,-1.0,1.0,3.0} │
-    │ dx//D//_Q_2  ┆ 24               ┆ {-3.0,-1.0,1.0,3.0} │
-    │ dx//D//_Q_3  ┆ 25               ┆ {-3.0,-1.0,1.0,3.0} │
-    │ dx//D//_Q_4  ┆ 26               ┆ {-3.0,-1.0,1.0,3.0} │
-    └──────────────┴──────────────────┴─────────────────────┘
+    shape: (25, 3)
+    ┌──────────────┬──────────────────┬───────────────────────┐
+    │ code         ┆ code/vocab_index ┆ values/quantiles      │
+    │ ---          ┆ ---              ┆ ---                   │
+    │ str          ┆ u32              ┆ struct[4]             │
+    ╞══════════════╪══════════════════╪═══════════════════════╡
+    │ lab//A       ┆ 0                ┆ {-3.0,-1.0,1.0,3.0}   │
+    │ lab//A//_Q_1 ┆ 1                ┆ {-3.0,-1.0,1.0,3.0}   │
+    │ lab//A//_Q_2 ┆ 2                ┆ {-3.0,-1.0,1.0,3.0}   │
+    │ lab//A//_Q_3 ┆ 3                ┆ {-3.0,-1.0,1.0,3.0}   │
+    │ lab//A//_Q_4 ┆ 4                ┆ {-3.0,-1.0,1.0,3.0}   │
+    │ …            ┆ …                ┆ …                     │
+    │ lab//F//_Q_2 ┆ 20               ┆ {-3.0,-1.0,1.0,3.0}   │
+    │ lab//F//_Q_3 ┆ 21               ┆ {-3.0,-1.0,1.0,3.0}   │
+    │ lab//F//_Q_4 ┆ 22               ┆ {-3.0,-1.0,1.0,3.0}   │
+    │ lab//F//_Q_5 ┆ 23               ┆ {-3.0,-1.0,1.0,3.0}   │
+    │ dx//D        ┆ 24               ┆ {null,null,null,null} │
+    └──────────────┴──────────────────┴───────────────────────┘
     """
     # Step 1: Add custom_quantiles column to code_metadata
     final_metadata_columns = code_metadata.columns
@@ -195,97 +361,131 @@ def convert_metadata_codes_to_discrete_quantiles(
     return quantile_code_metadata.select(final_metadata_columns)
 
 
-def add_custom_quantiles_column(code_metadata: pl.DataFrame, custom_quantiles: dict) -> pl.DataFrame:
-    # Convert custom_quantiles dict to a Polars Series
-    if isinstance(custom_quantiles, DictConfig):
-        custom_quantiles = OmegaConf.to_container(custom_quantiles)
-    custom_quantiles_series = pl.Series(
-        name="custom_quantiles",
-        values=[custom_quantiles.get(code) if code is not None else None for code in code_metadata["code"]],
-    )
-
-    # Add the custom_quantiles column to code_metadata
-    return code_metadata.with_columns(custom_quantiles_series)
-
-
-def process_quantiles(df: pl.DataFrame) -> pl.DataFrame:
-    # Use custom_quantiles if available, otherwise use values/quantiles
-    df = df.with_columns(
-        effective_quantiles=pl.when(pl.col("custom_quantiles").is_not_null())
-        .then(pl.col("custom_quantiles"))
-        .otherwise(pl.col("values/quantiles"))
-    )
-
-    # Unnest the effective_quantiles and calculate the quantile
-    quantile_columns = pl.selectors.starts_with("values/quantile/")
-    df = df.unnest("effective_quantiles").with_columns(
-        quantile=pl.when(pl.col("numeric_value").is_not_null()).then(
-            pl.sum_horizontal(quantile_columns.lt(pl.col("numeric_value"))).add(1)
-        )
-    )
-
-    # Create the new code with quantile information
-    code_quantile_concat = pl.concat_str(pl.col("code"), pl.lit("//_Q_"), pl.col("quantile"))
-    df = df.with_columns(
-        code=pl.when(pl.col("quantile").is_not_null()).then(code_quantile_concat).otherwise(pl.col("code"))
-    )
-
-    # Clean up intermediate columns
-    df = df.drop("quantile", "code/vocab_index", "values/quantiles", "custom_quantiles", quantile_columns)
-
-    return df
-
-
 def generate_quantile_code_metadata(code_metadata: pl.DataFrame) -> pl.DataFrame:
-    # Step 1: Determine the number of quantiles for each code
-    num_quantiles = len(code_metadata.schema["values/quantiles"].fields)
-    if isinstance(code_metadata.schema["custom_quantiles"], pl.Struct):
-        num_custom_quantiles = len(code_metadata.schema["custom_quantiles"].fields)
-        num_quantiles_expr = (
-            pl.when(pl.col("custom_quantiles").is_not_null())
-            .then(pl.lit(num_custom_quantiles) + 1)
-            .otherwise(pl.lit(num_quantiles) + 1)
-        )
-    else:
-        num_quantiles_expr = pl.lit(num_quantiles)
+    """Modifies the code_metadata DataFrame to include quantile codes.
 
-    code_metadata = code_metadata.with_columns(num_quantiles_expr.alias("num_quantiles"))
+    Args:
+        code_metadata (pl.DataFrame): Current code metadata DataFrame
+
+    Returns:
+        pl.DataFrame: dataframe where we duplicate rows for each quantile code.
+
+    Examples:
+    >>> from datetime import datetime
+    >>> code_metadata = pl.DataFrame(
+    ...     {
+    ...         "code": ["lab//A", "lab//C", "dx//B", "dx//E", "lab//F", "dx//D"],
+    ...         "code/vocab_index": [0, 1, 2, 3, 4, 5],
+    ...         "values/quantiles": [ # [[-3,-1,1,3], [-3,-1,1,3], [], [-3,-1,1,3], [-3,-1,1,3], [-3,-1,1,3]],
+    ...             {"values/quantile/0.2": -3, "values/quantile/0.4": -1,
+    ...                 "values/quantile/0.6": 1, "values/quantile/0.8": 3},
+    ...             {"values/quantile/0.2": -3, "values/quantile/0.4": -1,
+    ...                 "values/quantile/0.6": 1, "values/quantile/0.8": 3},
+    ...             {"values/quantile/0.2": None, "values/quantile/0.4": None,
+    ...                 "values/quantile/0.6": None, "values/quantile/0.8": None},
+    ...             {"values/quantile/0.2": -3, "values/quantile/0.4": -1,
+    ...                 "values/quantile/0.6": 1, "values/quantile/0.8": 3},
+    ...             {"values/quantile/0.2": -3, "values/quantile/0.4": -1,
+    ...                 "values/quantile/0.6": 1, "values/quantile/0.8": 3},
+    ...             {"values/quantile/0.2": None, "values/quantile/0.4": None,
+    ...                 "values/quantile/0.6": None, "values/quantile/0.8": None},
+    ...         ],
+    ...     },
+    ...     schema = {
+    ...         "code": pl.Utf8,
+    ...         "code/vocab_index": pl.UInt32,
+    ...         "values/quantiles": pl.Struct([
+    ...             pl.Field("values/quantile/0.2", pl.Float64),
+    ...             pl.Field("values/quantile/0.4", pl.Float64),
+    ...             pl.Field("values/quantile/0.6", pl.Float64),
+    ...             pl.Field("values/quantile/0.8", pl.Float64),
+    ...         ]), # pl.List(pl.Float64),
+    ...     },
+    ... )
+    >>> quantile_code_metadata = generate_quantile_code_metadata(code_metadata)
+    >>> quantile_code_metadata.sort("code/vocab_index")
+    shape: (26, 3)
+    ┌──────────────────┬───────────────────────┬──────────────┐
+    │ code/vocab_index ┆ values/quantiles      ┆ code         │
+    │ ---              ┆ ---                   ┆ ---          │
+    │ u32              ┆ struct[4]             ┆ str          │
+    ╞══════════════════╪═══════════════════════╪══════════════╡
+    │ 0                ┆ {-3.0,-1.0,1.0,3.0}   ┆ lab//A       │
+    │ 1                ┆ {-3.0,-1.0,1.0,3.0}   ┆ lab//A//_Q_1 │
+    │ 2                ┆ {-3.0,-1.0,1.0,3.0}   ┆ lab//A//_Q_2 │
+    │ 3                ┆ {-3.0,-1.0,1.0,3.0}   ┆ lab//A//_Q_3 │
+    │ 4                ┆ {-3.0,-1.0,1.0,3.0}   ┆ lab//A//_Q_4 │
+    │ …                ┆ …                     ┆ …            │
+    │ 21               ┆ {-3.0,-1.0,1.0,3.0}   ┆ lab//F//_Q_2 │
+    │ 22               ┆ {-3.0,-1.0,1.0,3.0}   ┆ lab//F//_Q_3 │
+    │ 23               ┆ {-3.0,-1.0,1.0,3.0}   ┆ lab//F//_Q_4 │
+    │ 24               ┆ {-3.0,-1.0,1.0,3.0}   ┆ lab//F//_Q_5 │
+    │ 25               ┆ {null,null,null,null} ┆ dx//D        │
+    └──────────────────┴───────────────────────┴──────────────┘
+    """
+    # Step 1: Get the number of quantiles
+    quantile_fields = code_metadata.schema["values/quantiles"].fields
+    num_bins = len(quantile_fields) + 1  # Add 1 for n+1 bins
+    codes_per_entry = num_bins + 1  # Add 1 for the original code
+
+    # Get first quantile name
+    first_quantile = quantile_fields[0].name
+    is_null_quantile = code_metadata.select(pl.col("values/quantiles").struct.field(first_quantile).is_null())
+
+    # Determine number of bins per row
+    codes_per_entry_expr = pl.when(is_null_quantile).then(1).otherwise(codes_per_entry)
+
+    # If custom quantiles exist, update the expression
+    if "custom_quantiles" in code_metadata.columns and isinstance(
+        code_metadata.schema["custom_quantiles"], pl.Struct
+    ):
+        custom_bins = len(code_metadata.schema["custom_quantiles"].fields) + 2
+        codes_per_entry_expr = (
+            pl.when(pl.col("custom_quantiles").is_not_null())
+            .then(custom_bins + 2)
+            .otherwise(codes_per_entry_expr)
+        )
+
+    code_metadata = code_metadata.with_columns(codes_per_entry_expr.alias("codes_per_entry_expr"))
 
     # Step 2: Generate rows for each code and its quantiles
     expanded_metadata = (
         code_metadata.select(
-            pl.col("code").repeat_by(pl.col("num_quantiles")),
-            pl.col("code/vocab_index").repeat_by(pl.col("num_quantiles")).alias("base_index"),
+            pl.col("code").repeat_by(pl.col("codes_per_entry_expr")),
+            pl.col("code/vocab_index").repeat_by(pl.col("codes_per_entry_expr")).alias("base_index"),
             pl.exclude("code", "code/vocab_index"),
         )
         .explode(["code", "base_index"])
         .with_row_index()
     )
 
-    # Step 3: Generate quantile indices and adjust vocab indices
+    # Step 3: Generate binned code vocab indices and adjust vocab indices
     offset = (
         expanded_metadata.group_by("code", maintain_order=True)
-        .agg(pl.col("base_index").first(), pl.col("num_quantiles").first())
-        .select(pl.col("code"), pl.col("num_quantiles").cum_sum().alias("offset") - pl.col("num_quantiles"))
+        .agg(pl.col("base_index").first(), pl.col("codes_per_entry_expr").first())
+        .select(
+            pl.col("code"),
+            pl.col("codes_per_entry_expr").cum_sum().alias("offset") - pl.col("codes_per_entry_expr"),
+        )
     )
     expanded_metadata = expanded_metadata.join(offset, on="code", how="left")
     assert expanded_metadata["base_index"].is_sorted()
     expanded_metadata = expanded_metadata.with_columns((pl.col("index") - pl.col("offset")).alias("quantile"))
     expanded_metadata = expanded_metadata.rename({"index": "code/vocab_index"}).drop(
-        "custom_quantiles", "num_quantiles", "offset"
+        "codes_per_entry_expr", "offset"
     )
+    if "custom_quantiles" in expanded_metadata.columns:
+        expanded_metadata = expanded_metadata.drop("custom_quantiles")
 
     # Step 4: Generate quantile codes
     expanded_metadata = expanded_metadata.with_columns(
-        quantile_code=pl.when(pl.col("quantile") != 0)
+        binned_code=pl.when(pl.col("quantile") != 0)
         .then(pl.concat_str(pl.col("code"), pl.lit("//_Q_"), pl.col("quantile").cast(pl.Utf8)))
         .otherwise(pl.col("code"))
     )
 
     # Step 5: Select and rename final columns
-    final_metadata = expanded_metadata.drop("base_index", "code", "quantile").rename(
-        {"quantile_code": "code"}
-    )
+    final_metadata = expanded_metadata.drop("base_index", "code", "quantile").rename({"binned_code": "code"})
 
     return final_metadata
 
@@ -406,30 +606,34 @@ def quantile_normalize(
         │ lab//F ┆ 5                ┆ {-3.0,-1.0,1.0,3.0}   │
         └────────┴──────────────────┴───────────────────────┘
         >>> quantile_normalize(MEDS_df.lazy(), code_metadata).collect().sort("subject_id", "time", "code")
-        shape: (4, 4)
+        shape: (6, 4)
         ┌────────────┬─────────────────────┬──────┬───────────────┐
         │ subject_id ┆ time                ┆ code ┆ numeric_value │
         │ ---        ┆ ---                 ┆ ---  ┆ ---           │
         │ u32        ┆ datetime[μs]        ┆ u32  ┆ f64           │
         ╞════════════╪═════════════════════╪══════╪═══════════════╡
         │ 1          ┆ 2021-01-01 00:00:00 ┆ 3    ┆ 1.0           │
-        │ 1          ┆ 2021-01-02 00:00:00 ┆ 8    ┆ null          │
-        │ 2          ┆ 2022-10-02 00:00:00 ┆ 4    ┆ null          │
-        │ 3          ┆ 2022-10-02 00:00:00 ┆ 16   ┆ null          │
+        │ 1          ┆ 2021-01-01 00:00:00 ┆ 4    ┆ 3.0           │
+        │ 1          ┆ 2021-01-02 00:00:00 ┆ 12   ┆ null          │
+        │ 2          ┆ 2022-10-02 00:00:00 ┆ 4    ┆ 3.0           │
+        │ 2          ┆ 2022-10-02 00:00:00 ┆ 6    ┆ null          │
+        │ 3          ┆ 2022-10-02 00:00:00 ┆ 19   ┆ null          │
         └────────────┴─────────────────────┴──────┴───────────────┘
         >>> custom_quantiles = {"lab//A": {"values/quantile/0.5": 2}}
         >>> quantile_normalize(MEDS_df.lazy(), code_metadata, custom_quantiles=custom_quantiles
         ...     ).collect().sort("subject_id", "time", "code")
-        shape: (4, 4)
+            shape: (6, 4)
         ┌────────────┬─────────────────────┬──────┬───────────────┐
         │ subject_id ┆ time                ┆ code ┆ numeric_value │
         │ ---        ┆ ---                 ┆ ---  ┆ ---           │
         │ u32        ┆ datetime[μs]        ┆ u32  ┆ f64           │
         ╞════════════╪═════════════════════╪══════╪═══════════════╡
         │ 1          ┆ 2021-01-01 00:00:00 ┆ 1    ┆ 1.0           │
-        │ 1          ┆ 2021-01-02 00:00:00 ┆ 7    ┆ null          │
-        │ 2          ┆ 2022-10-02 00:00:00 ┆ 2    ┆ null          │
-        │ 3          ┆ 2022-10-02 00:00:00 ┆ 17   ┆ null          │
+        │ 1          ┆ 2021-01-01 00:00:00 ┆ 2    ┆ 3.0           │
+        │ 1          ┆ 2021-01-02 00:00:00 ┆ 11   ┆ null          │
+        │ 2          ┆ 2022-10-02 00:00:00 ┆ 2    ┆ 3.0           │
+        │ 2          ┆ 2022-10-02 00:00:00 ┆ 5    ┆ null          │
+        │ 3          ┆ 2022-10-02 00:00:00 ┆ 18   ┆ null          │
         └────────────┴─────────────────────┴──────┴───────────────┘
     """
     # TODO: add support for original values/mean and values/std normalization of continuous values

--- a/src/meds_torch/utils/utils.py
+++ b/src/meds_torch/utils/utils.py
@@ -56,7 +56,7 @@ def task_wrapper(task_func: Callable) -> Callable:
 
     def wrap(cfg: DictConfig, **kwargs) -> tuple[dict[str, Any], dict[str, Any]]:
         cfg.paths.time_output_dir = Path(cfg.paths.time_output_dir)
-        cfg.paths.time_output_dir.mkdir(exist_ok=True)
+        cfg.paths.time_output_dir.mkdir(parents=True, exist_ok=True)
         OmegaConf.save(config=cfg, f=Path(cfg.paths.time_output_dir) / "hydra_config.yaml")
         # execute the task
         try:

--- a/src/meds_torch/utils/utils.py
+++ b/src/meds_torch/utils/utils.py
@@ -1,9 +1,10 @@
 import warnings
 from collections.abc import Callable
 from importlib.util import find_spec
+from pathlib import Path
 from typing import Any
 
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from meds_torch.utils import pylogger, rich_utils
 
@@ -54,6 +55,9 @@ def task_wrapper(task_func: Callable) -> Callable:
     """
 
     def wrap(cfg: DictConfig, **kwargs) -> tuple[dict[str, Any], dict[str, Any]]:
+        cfg.paths.time_output_dir = Path(cfg.paths.time_output_dir)
+        cfg.paths.time_output_dir.mkdir(exist_ok=True)
+        OmegaConf.save(config=cfg, f=Path(cfg.paths.time_output_dir) / "hydra_config.yaml")
         # execute the task
         try:
             outputs = task_func(cfg=cfg, **kwargs)

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -141,7 +141,7 @@ def test_finetune_multiseed(tmp_path: Path, get_kwargs, meds_dir) -> None:  # no
     :param tmp_path: The temporary logging path.
     :param cfg_train: A DictConfig containing a valid training configuration.
     """
-    kwargs = get_kwargs(extra_overrides=["callbacks=tune_default", "hparams_search=ray_tune"])
+    kwargs = get_kwargs(extra_overrides=["callbacks=tune_default", "hparams_search=ray_tune", "trainer=ray"])
     cfg_pretrain = kwargs["cfg"]
     raises_value_error = kwargs["raises_value_error"]
     HydraConfig().set_config(cfg_pretrain)
@@ -152,7 +152,6 @@ def test_finetune_multiseed(tmp_path: Path, get_kwargs, meds_dir) -> None:  # no
     with open_dict(cfg_pretrain):
         cfg_pretrain.trainer.max_epochs = 1
         cfg_pretrain.paths.output_dir = str(pretrain_path)
-        cfg_pretrain.callbacks.model_checkpoint.save_top_k = -1
         cfg_pretrain.hparams_search.ray.num_samples = 2
         cfg_pretrain.hparams_search.scheduler.grace_period = 1
         cfg_pretrain.trainer.accelerator = "gpu"
@@ -179,7 +178,7 @@ def test_finetune_multiseed(tmp_path: Path, get_kwargs, meds_dir) -> None:  # no
         supervised_input_kwargs["early_fusion"] = None
         overrides, _, supervised = get_overrides_and_exceptions(**supervised_input_kwargs)
         cfg_finetune = create_cfg(
-            overrides=overrides + ["callbacks=tune_default", "hparams_search=ray_tune"],
+            overrides=overrides + ["callbacks=tune_default", "hparams_search=ray_tune", "trainer=ray"],
             meds_dir=meds_dir,
             config_name="finetune.yaml",
             supervised=supervised,
@@ -189,7 +188,6 @@ def test_finetune_multiseed(tmp_path: Path, get_kwargs, meds_dir) -> None:  # no
             cfg_finetune.pretrain_path = str(latest_pretrain_path.resolve())
             cfg_finetune.paths.output_dir = str(finetune_path)
             cfg_finetune.trainer.max_epochs = 2
-            cfg_finetune.callbacks.model_checkpoint.save_top_k = -1
             cfg_finetune.hparams_search.ray.num_samples = 2
             cfg_finetune.hparams_search.scheduler.grace_period = 1
             cfg_finetune.trainer.accelerator = "gpu"
@@ -207,7 +205,7 @@ def test_finetune_multiseed(tmp_path: Path, get_kwargs, meds_dir) -> None:  # no
 
         # multiseed finetune
         cfg_finetune = create_cfg(
-            overrides=overrides + ["callbacks=tune_default", "hparams_search=ray_multiseed"],
+            overrides=overrides + ["callbacks=tune_default", "hparams_search=ray_multiseed", "trainer=ray"],
             meds_dir=meds_dir,
             config_name="finetune.yaml",
             supervised=supervised,
@@ -216,7 +214,6 @@ def test_finetune_multiseed(tmp_path: Path, get_kwargs, meds_dir) -> None:  # no
             cfg_finetune.pretrain_path = str(latest_finetune_path.resolve())
             cfg_finetune.paths.output_dir = str(multiseed_finetune_path)
             cfg_finetune.trainer.max_epochs = 2
-            cfg_finetune.callbacks.model_checkpoint.save_top_k = -1
             cfg_finetune.hparams_search.ray.num_samples = 2
             cfg_finetune.trainer.accelerator = "gpu"
 


### PR DESCRIPTION
This should be merged after #67 

This pull request includes the following updates:

1. Cleaned up docstrings for the pytorch_dataset class
2. Integrated necessary configuration changes to support tuning
3. Improved Quantile Binning for EIC:
   - Updated quantile binning for EIC to exclude non-numeric bins for vocab indices.
4. Refactored `tune.py` Job Launching Script:
   - Made `tune.py` more DRY by consolidating training and finetuning logic from `train.py` and `finetune.py`.
   - Resolved a bug with checkpointing in hyperparameter tuning:
     - Disabled PyTorch Lightning's model checkpoint callback.
     - Used Ray Tune’s checkpointing to avoid conflicts with multiple trials writing to the same directory.
5. Updated slow finetuning and CLI tests to handle distributed finetuning and support multiseed and hyperparameter sweeps effectively. These are not run by github actions as it skips these slow guys.