### PR TITLE
Fix textcode encoder returning zeros

### DIFF
--- a/src/meds_torch/input_encoder/textcode_encoder.py
+++ b/src/meds_torch/input_encoder/textcode_encoder.py
@@ -185,7 +185,7 @@ class TextCodeEmbedder(nn.Module, Module, TimeableMixin):
         code_embeddings = self.linear(code_embeddings)
         embeddings = code_embeddings[inverse_indices]
 
-        return torch.zeros_like(embeddings)
+        return embeddings
 
 
 class TextCodeEncoder(nn.Module, Module, TimeableMixin):


### PR DESCRIPTION
Fixes bug in TextCodeEmbedder.forward() where it was returning zeros instead of computed embeddings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where text-code embeddings were output as zero vectors. The encoder now returns the actual computed embeddings, ensuring meaningful representation of inputs.
  * Improves accuracy and behavior of any features relying on these embeddings (e.g., similarity, classification, or retrieval), leading to more reliable results and downstream performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->